### PR TITLE
Command line arguments for `Vcloud::Converter.convert`

### DIFF
--- a/bin/convert
+++ b/bin/convert
@@ -1,0 +1,21 @@
+#!/usr/bin/env ruby
+
+require "bundler/setup"
+require "vcloud/converter"
+require "optparse"
+
+ARGV << '-h' if ARGV.empty?
+options = {}
+OptionParser.new do |opts|
+  opts.banner = "Usage: ./bin/convert -t vcloud-net_launcher -p path/to/file.yaml"
+
+  opts.on('-t', '--type TYPE', 'Type of YAML file for conversion.') { |v| options[:type] = v }
+  opts.on('-p', '--path PATH', 'Path to YAML file for conversion.') { |v| options[:path] = v }
+
+  opts.on_tail("-h", "--help", "Show this help message.") do
+    puts opts
+    exit
+  end
+end.parse!
+
+Vcloud::Converter.convert(options[:type], options[:path])

--- a/lib/vcloud/converter.rb
+++ b/lib/vcloud/converter.rb
@@ -2,6 +2,7 @@ require "vcloud/converter/version"
 
 module Vcloud
   module Converter
-    # Your code goes here...
+    def self.convert(conversion_type, file_path)
+    end
   end
 end


### PR DESCRIPTION
- Create a `bin` script to not clutter up the converter script with command line stuff.